### PR TITLE
Added URL for database identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Above, we are created a parameters dictionary to convert from Uniprot accession.
 - `from` input format id type (uniprot acc and id)
 - `to` output format id type (RefSeq nucleotide sequence id)
 
+For all the acceptable formats for `from` and `to`, you can visit https://www.uniprot.org/help/api_idmapping
 
 
 ```python


### PR DESCRIPTION
Just added a URL that has the list of IDs UniProt accepts as database identifiers for mapping.